### PR TITLE
feat: 멘티 리스트 조회 API 추가

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -6,9 +6,11 @@ from .models import (
     Todo,
     Pomo,
     Concentration,
+    MentorMentee,
     DayOfWeek,
     Priority,
     TodoStatus,
+    UserRole,
     UsageEventType,
     PomoCategory
 )
@@ -21,9 +23,11 @@ __all__ = [
     "Todo",
     "Pomo",
     "Concentration",
+    "MentorMentee",
     "DayOfWeek",
     "Priority",
     "TodoStatus",
+    "UserRole",
     "UsageEventType",
     "PomoCategory",
 ]

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -137,6 +137,24 @@ class Todo(Base):
         Index('idx_todos_status', 'status'),
     )
 
+class MentorMentee(Base):
+    __tablename__ = "mentor_mentee"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    mentor_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    mentee_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    mentor = relationship("User", foreign_keys=[mentor_id], backref="mentees_rel")
+    mentee = relationship("User", foreign_keys=[mentee_id], backref="mentor_rel")
+
+    __table_args__ = (
+        UniqueConstraint('mentor_id', 'mentee_id', name='unique_mentor_mentee'),
+        Index('idx_mentor_mentee_mentor', 'mentor_id'),
+        Index('idx_mentor_mentee_mentee', 'mentee_id'),
+    )
+
+
 class Pomo(Base):
     __tablename__ = "pomo"
 

--- a/app/repositories/__init__.py
+++ b/app/repositories/__init__.py
@@ -2,10 +2,12 @@ from .planner_repository import planner_repo
 from .todo_repository import todo_repo
 from .pomo_repository import pomo_repo
 from .concentration_repository import concentration_repo
+from .mentoring_repository import mentoring_repo
 
 __all__ = [
     "planner_repo",
     "todo_repo",
     "pomo_repo",
     "concentration_repo",
+    "mentoring_repo",
 ]

--- a/app/repositories/mentoring_repository.py
+++ b/app/repositories/mentoring_repository.py
@@ -1,0 +1,39 @@
+import uuid
+from typing import List, Tuple, Optional
+
+from sqlalchemy.orm import Session, joinedload
+
+from app.models import MentorMentee
+
+
+class MentoringRepository:
+    def get_mentees_by_mentor(
+        self,
+        db: Session,
+        mentor_id: uuid.UUID,
+        skip: int = 0,
+        limit: int = 20,
+    ) -> Tuple[List[MentorMentee], int]:
+        query = (
+            db.query(MentorMentee)
+            .options(joinedload(MentorMentee.mentee))
+            .filter(MentorMentee.mentor_id == mentor_id)
+        )
+        total_items = query.count()
+        results = query.order_by(MentorMentee.created_at.desc()).offset(skip).limit(limit).all()
+        return results, total_items
+
+    def get_by_mentor_and_mentee(
+        self, db: Session, mentor_id: uuid.UUID, mentee_id: uuid.UUID
+    ) -> Optional[MentorMentee]:
+        return (
+            db.query(MentorMentee)
+            .filter(
+                MentorMentee.mentor_id == mentor_id,
+                MentorMentee.mentee_id == mentee_id,
+            )
+            .first()
+        )
+
+
+mentoring_repo = MentoringRepository()

--- a/app/routers/api_v1.py
+++ b/app/routers/api_v1.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from app.routers import planners, todos, statistics, pomo
+from app.routers import planners, todos, statistics, pomo, mentoring
 from app.routers.auth import auth_router
 
 api_v1_router = APIRouter()
@@ -9,3 +9,4 @@ api_v1_router.include_router(planners.router, prefix="/planners", tags=["Planner
 api_v1_router.include_router(todos.router, prefix="/todos", tags=["Todos"])
 api_v1_router.include_router(statistics.router, prefix="/statistics", tags=["Statistics"])
 api_v1_router.include_router(pomo.router, prefix="/pomos", tags=["Pomo"])
+api_v1_router.include_router(mentoring.router, prefix="/mentoring", tags=["Mentoring"])

--- a/app/routers/mentoring.py
+++ b/app/routers/mentoring.py
@@ -1,0 +1,35 @@
+import math
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models import User
+from app.schemas import PaginatedResponseModel
+from app.schemas.mentoring_schemas import MentorMenteeResponse
+from app.services.mentoring_service import mentoring_service
+from app.auth.permissions import get_current_mentor
+
+router = APIRouter()
+
+
+@router.get("/mentees", response_model=PaginatedResponseModel[MentorMenteeResponse])
+async def get_mentee_list(
+    page: int = 1,
+    limit: int = 10,
+    db: Session = Depends(get_db),
+    mentor: User = Depends(get_current_mentor),
+):
+    mentees, total_items = mentoring_service.get_mentees(db, mentor, page, limit)
+    total_pages = math.ceil(total_items / limit) if total_items > 0 else 0
+
+    return {
+        "success": True,
+        "data": mentees,
+        "pagination": {
+            "current_page": page,
+            "total_pages": total_pages,
+            "total_items": total_items,
+            "items_per_page": limit,
+        },
+    }

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -35,6 +35,10 @@ from .pomo_schemas import (
     ConcentrationResponse,
     PomoUpdateResponse,
 )
+from .mentoring_schemas import (
+    MenteeResponse,
+    MentorMenteeResponse,
+)
 
 
 __all__ = [
@@ -65,5 +69,7 @@ __all__ = [
     "PomoUpdateResponse",
     "ConcentrationCreate",
     "ConcentrationResponse",
+    "MenteeResponse",
+    "MentorMenteeResponse",
 ]
 

--- a/app/schemas/mentoring_schemas.py
+++ b/app/schemas/mentoring_schemas.py
@@ -1,0 +1,25 @@
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class MenteeResponse(BaseModel):
+    id: uuid.UUID
+    username: Optional[str] = None
+    full_name: Optional[str] = None
+    profile_image: Optional[str] = None
+    created_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class MentorMenteeResponse(BaseModel):
+    id: uuid.UUID
+    mentor_id: uuid.UUID
+    mentee_id: uuid.UUID
+    mentee: MenteeResponse
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -2,10 +2,12 @@ from .planner_service import planner_service
 from .todo_service import todo_service
 from .pomo_service import pomo_service
 from .statistics_service import statistics_service
+from .mentoring_service import mentoring_service
 
 __all__ = [
     "planner_service",
     "todo_service",
     "pomo_service",
     "statistics_service",
+    "mentoring_service",
 ]

--- a/app/services/mentoring_service.py
+++ b/app/services/mentoring_service.py
@@ -1,0 +1,22 @@
+import uuid
+from typing import List, Tuple
+
+from sqlalchemy.orm import Session
+
+from app.models import User, MentorMentee
+from app.repositories.mentoring_repository import mentoring_repo
+
+
+class MentoringService:
+    def get_mentees(
+        self,
+        db: Session,
+        mentor: User,
+        page: int,
+        limit: int,
+    ) -> Tuple[List[MentorMentee], int]:
+        skip = (page - 1) * limit
+        return mentoring_repo.get_mentees_by_mentor(db, mentor.id, skip, limit)
+
+
+mentoring_service = MentoringService()


### PR DESCRIPTION
멘토가 자신의 멘티 목록을 페이지네이션으로 조회할 수 있는 API 구현
- MentorMentee 관계 테이블 모델 추가
- GET /mentoring/mentees 엔드포인트 추가
- 멘토링 schema, repository, service, router 레이어 생성